### PR TITLE
Fix: Themes are not working (Issue #5)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -51,9 +51,11 @@ RUN /usr/sbin/usermod -l $USER duke \
 # ╰――――――――――――――――――――╯
 RUN /sbin/apk add --no-cache graphviz  bash 
 COPY --from=BUILD "/opt/structurizr/structurizr-application/target/structurizr-${IMAGE_VERSION}.war" /opt/structurizr/structurizr.war
+COPY --from=BUILD /opt/structurizr/structurizr-themes /home/dsl/structurizr-themes
 COPY structurizr.s6 /etc/services.d/structurizr/run
 RUN rm -rf /etc/services.d/java \
  && ln -fsv /mnt/volumes/data/workspace "/home/${USER}/workspace" \
+ && chown "${USER}:${USER}" -R /home/dsl/structurizr-themes \
  && chown "${USER}:${USER}" -R "/home/${USER}" /opt
 # WORKDIR /opt/structurizr
 # ADD "https://github.com/structurizr/lite/releases/download/v${IMAGE_VERSION}/structurizr-lite.war" structurizr.war


### PR DESCRIPTION
Bakes Structurizr themes into the container image and ensures correct ownership for the `dsl` user. \n\n- Cloned themes in BUILD stage\n- Copied themes to `/home/dsl/structurizr-themes` in CONTAINER stage\n- Set ownership for the themes directory\n\nAC status:\n- [x] Themes baked into image [Develop]\n- [ ] Themes accessible at runtime [Run]\n\nRisk: Low\nCI: Pending\n\nHanding off to integration stage.